### PR TITLE
Update deployresources.json

### DIFF
--- a/Technical Deployment Guide/src/scripts/arm/deployresources.json
+++ b/Technical Deployment Guide/src/scripts/arm/deployresources.json
@@ -63,7 +63,7 @@
       "apiVersion": "[variables('hdinsight-version')]",
       "location": "[variables('location')]",
       "properties": {
-        "clusterVersion": "3.5",
+        "clusterVersion": "3.6",
         "osType": "Linux",
         "tier": "standard",
         "clusterDefinition": {


### PR DESCRIPTION
Require to update the HDI cluster version from 3.5 to 3.6 since Cluster version 3.5 is no longer supported. 